### PR TITLE
Add macOS support to C++ SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![banner](/banner.png)
 
-> The lastest build of the C++ SDK will only compile if building a Windows application. We are currently working on supporting other systems like Unix/Linux and MacOS.
+> The C++ SDK supports both Windows and macOS. Linux support is coming soon.
 
 * [Installation](#installation)
     * [Static Libraries](#static-libraries)

--- a/include/system.hpp
+++ b/include/system.hpp
@@ -14,9 +14,13 @@
 
 #if defined _WIN32 || defined _WIN64 || defined __CYGWIN__
 #include <windows.h>
+#elif defined __APPLE__
+#include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/IOKitLib.h>
+#include <mach-o/dyld.h>
+#include <unistd.h>
 #else
-// Note: This is a temporary solution while the API is in development. Eventually we will support other platforms.
-#error "This code can only be compiled on Windows."
+#error "This code can only be compiled on Windows or macOS."
 #endif
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,12 @@ target_link_libraries (tsar PRIVATE OpenSSL::SSL OpenSSL::Crypto)
 target_link_libraries (tsar PRIVATE CURL::libcurl)
 target_link_libraries (tsar PUBLIC nlohmann_json::nlohmann_json)
 
+# Link macOS frameworks
+if (APPLE)
+	target_link_libraries (tsar PRIVATE "-framework CoreFoundation")
+	target_link_libraries (tsar PRIVATE "-framework IOKit")
+endif()
+
 
 # Add the source files to the project
 target_sources (tsar PRIVATE

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -2,6 +2,8 @@
 
 namespace tsar::system
 {
+#if defined _WIN32 || defined _WIN64 || defined __CYGWIN__
+    // Windows implementations
     std::optional< std::string > hwid() noexcept
     {
         char szBuffer[ BUFSIZ ]{};
@@ -25,11 +27,10 @@ namespace tsar::system
 
         std::string current_exe(path);
 
-
         unsigned char hash[SHA256_DIGEST_LENGTH];
         SHA256_CTX sha256;
         SHA256_Init(&sha256);
-        
+
         std::ifstream file(current_exe, std::ifstream::binary);
 
         const size_t bufferSize = 32768;
@@ -38,7 +39,7 @@ namespace tsar::system
             file.read(buffer.data(), buffer.size());
             SHA256_Update(&sha256, buffer.data(), file.gcount());
         }
-        
+
         SHA256_Final(hash, &sha256);
 
         std::stringstream ss;
@@ -47,4 +48,92 @@ namespace tsar::system
         }
         return ss.str();
     }
+
+#elif defined __APPLE__
+    // macOS implementations
+    std::optional< std::string > hwid() noexcept
+    {
+        std::optional< std::string > result;
+
+        // Get the IO registry entry for the platform expert
+        io_service_t platformExpert = IOServiceGetMatchingService(kIOMasterPortDefault,
+                                                                   IOServiceMatching("IOPlatformExpertDevice"));
+
+        if (platformExpert) {
+            // Get the serial number
+            CFTypeRef serialNumberAsCFString =
+                IORegistryEntryCreateCFProperty(platformExpert,
+                                               CFSTR(kIOPlatformSerialNumberKey),
+                                               kCFAllocatorDefault, 0);
+
+            if (serialNumberAsCFString) {
+                if (CFGetTypeID(serialNumberAsCFString) == CFStringGetTypeID()) {
+                    CFStringRef serialNumber = (CFStringRef)serialNumberAsCFString;
+                    CFIndex length = CFStringGetLength(serialNumber);
+                    CFIndex maxSize = CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8) + 1;
+
+                    std::vector<char> buffer(maxSize);
+                    if (CFStringGetCString(serialNumber, buffer.data(), maxSize, kCFStringEncodingUTF8)) {
+                        result = std::string(buffer.data());
+                    }
+                }
+                CFRelease(serialNumberAsCFString);
+            }
+
+            IOObjectRelease(platformExpert);
+        }
+
+        return result;
+    }
+
+    bool open_browser( const std::string_view url ) noexcept
+    {
+        std::string command = "open \"" + std::string(url) + "\"";
+        return system(command.c_str()) == 0;
+    }
+
+    std::string get_hash() noexcept
+    {
+        char path[PATH_MAX];
+        uint32_t size = sizeof(path);
+
+        // Get the executable path
+        if (_NSGetExecutablePath(path, &size) != 0) {
+            return "";
+        }
+
+        // Resolve any symlinks to get the real path
+        char realPath[PATH_MAX];
+        if (realpath(path, realPath) == nullptr) {
+            return "";
+        }
+
+        std::string current_exe(realPath);
+
+        unsigned char hash[SHA256_DIGEST_LENGTH];
+        SHA256_CTX sha256;
+        SHA256_Init(&sha256);
+
+        std::ifstream file(current_exe, std::ifstream::binary);
+        if (!file.good()) {
+            return "";
+        }
+
+        const size_t bufferSize = 32768;
+        std::vector<char> buffer(bufferSize);
+        while (file.good()) {
+            file.read(buffer.data(), buffer.size());
+            SHA256_Update(&sha256, buffer.data(), file.gcount());
+        }
+
+        SHA256_Final(hash, &sha256);
+
+        std::stringstream ss;
+        for (int i = 0; i < SHA256_DIGEST_LENGTH; ++i) {
+            ss << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(hash[i]);
+        }
+        return ss.str();
+    }
+#endif
+
 }  // namespace tsar::system


### PR DESCRIPTION
Implement platform-specific functionality for macOS:
- Hardware ID retrieval using IOKit serial number
- Browser opening using 'open' command
- Executable hash calculation with macOS path resolution

Update CMakeLists.txt to link CoreFoundation and IOKit frameworks on macOS. Update README to reflect Windows and macOS support.